### PR TITLE
ENH: Support for 42

### DIFF
--- a/shell-restarter@koolskateguy89.github.io/metadata.json
+++ b/shell-restarter@koolskateguy89.github.io/metadata.json
@@ -4,7 +4,8 @@
   "shell-version": [
     "3.36",
     "3.38",
-    "40"
+    "40",
+    "42"
   ],
   "settings-schema": "org.gnome.shell.extensions.shell-restarter",
   "url": "https://github.com/koolskateguy89/gnome-shell-extension-shell-restarter",


### PR DESCRIPTION
I just upgraded to Ubuntu 22.04, which has `GNOME Shell 42.0`. Adding this line and restarting gnome-shell, the icon now appears properly and clicking it works. So hopefully this is all that should be necessary to make it work!